### PR TITLE
feat: Support configurable srcs (srcs with select)

### DIFF
--- a/yq/tests/BUILD.bazel
+++ b/yq/tests/BUILD.bazel
@@ -42,6 +42,19 @@ diff_test(
     file2 = ":case_dot_expression",
 )
 
+# srcs could be select() statements
+yq(
+    name = "case_select_srcs",
+    srcs = select({"//conditions:default": ["a.yaml"]}),
+    expression = ".",
+)
+
+diff_test(
+    name = "case_select_srcs_test",
+    file1 = "a.yaml",
+    file2 = ":case_select_srcs",
+)
+
 yq(
     name = "case_dot_expression_otherextension",
     srcs = ["a.whatever"],

--- a/yq/yq.bzl
+++ b/yq/yq.bzl
@@ -71,8 +71,10 @@ def yq(name, srcs, expression = ".", args = [], outs = None, **kwargs):
             elif outs[0].endswith(".tsv") and "-o=t" not in args and "--outputformat=tsv" not in args:
                 args.append("-o=t")
 
-    # If the input files are json or xml, set the parse flag if it isn't already set
-    if len(srcs) > 0:
+    # If the input files are json or xml, set the parse flag if it isn't already set.
+    # Select statements can't be inspected by macros, so if you're using configurable
+    # attributes, you'll need to add the -P or -p=xml arguments yourself as needed.
+    if type(srcs) != "select" and len(srcs) > 0:
         if srcs[0].endswith(".json") and "-P" not in args:
             args.append("-P")
         elif srcs[0].endswith(".xml") and "-p=xml" not in args:


### PR DESCRIPTION
Sometimes you want to act on different input files depending on the platform or some string flag you've defined. Prior to this change, that would fail, because you can't call len() on a "select", or for that matter inspect it using the index operator. With this patch, we skip the check for .json or .xml files if we encounter a "select" in the srcs attribute; if the user wants both .json/.xml and configurable attributes, they need to add the appropriate flag to args themselves.