### PR TITLE
feat: Support Label objects in srcs

### DIFF
--- a/yq/tests/BUILD.bazel
+++ b/yq/tests/BUILD.bazel
@@ -55,6 +55,19 @@ diff_test(
     file2 = ":case_select_srcs",
 )
 
+# srcs could contain Label objects
+yq(
+    name = "case_label_srcs",
+    srcs = [package_relative_label("a.yaml")],
+    expression = ".",
+)
+
+diff_test(
+    name = "case_label_srcs_test",
+    file1 = "a.yaml",
+    file2 = ":case_select_srcs",
+)
+
 yq(
     name = "case_dot_expression_otherextension",
     srcs = ["a.whatever"],

--- a/yq/yq.bzl
+++ b/yq/yq.bzl
@@ -75,9 +75,10 @@ def yq(name, srcs, expression = ".", args = [], outs = None, **kwargs):
     # Select statements can't be inspected by macros, so if you're using configurable
     # attributes, you'll need to add the -P or -p=xml arguments yourself as needed.
     if type(srcs) != "select" and len(srcs) > 0:
-        if srcs[0].endswith(".json") and "-P" not in args:
+        first_label = native.package_relative_label(srcs[0])
+        if first_label.name.endswith(".json") and "-P" not in args:
             args.append("-P")
-        elif srcs[0].endswith(".xml") and "-p=xml" not in args:
+        elif first_label.name.endswith(".xml") and "-p=xml" not in args:
             args.append("-p=xml")
 
     _yq_rule(


### PR DESCRIPTION
The srcs argument to yq is supposed to be a list of input file labels, but it did not actually support Label objects, only labels in their string form. This patch adds support for Label objects in srcs.

This is useful in particular when yq is called from a macro, as "outer macros should always prefer to pass Label objects to inner macros rather than label strings" (according to the documentation of package_relative_label). Symbolic macros also steer the macro writer towards using Label objects over label strings.