### PR TITLE
fix: Adjust case_label_srcs_test to test the right file

### DIFF
--- a/yq/tests/BUILD.bazel
+++ b/yq/tests/BUILD.bazel
@@ -65,7 +65,7 @@ yq(
 diff_test(
     name = "case_label_srcs_test",
     file1 = "a.yaml",
-    file2 = ":case_select_srcs",
+    file2 = ":case_label_srcs",
 )
 
 yq(


### PR DESCRIPTION
The test case for a Label object in the srcs attribute should actually use the corresponding target, rather than the file created by the previous test before that. (The test case is sort of redundant, in the sense that the "case_label_srcs" fails to build at all without the change to support Label objects, but if we want to have the test case anyway, it should at least test the right file.)

The error was introduced in #18. (Sorry about that.)