### PR TITLE
chore: add windows_arm64 support

### DIFF
--- a/yq/toolchain/mirror_release.sh
+++ b/yq/toolchain/mirror_release.sh
@@ -21,7 +21,7 @@ chmod u+x extract-checksum.sh
 
 # Extract the checksums and output a starlark map entry
 echo "\"$version\": {"
-platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,riscv64,ppc64le} windows_amd64)
+platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,riscv64,ppc64le} windows_{amd64,arm64})
 for release in ${platforms[@]}; do
   artifact=$release
   if [[ $release == windows* ]]; then

--- a/yq/toolchain/platforms.bzl
+++ b/yq/toolchain/platforms.bzl
@@ -52,6 +52,12 @@ YQ_PLATFORMS = {
             "@platforms//cpu:x86_64",
         ],
     ),
+    "windows_arm64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
 }
 
 def _yq_platform_repo_impl(rctx):

--- a/yq/toolchain/versions.bzl
+++ b/yq/toolchain/versions.bzl
@@ -2,7 +2,7 @@
 
 # Note: this is not the latest release, because it has significant breaking changes.
 # See https://github.com/bazel-contrib/bazel-lib/pull/421
-DEFAULT_YQ_VERSION = "4.45.1"
+DEFAULT_YQ_VERSION = "4.45.2"
 
 # The integrity hashes can be automatically fetched for the latest yq release by running
 # `tools/yq_mirror_release.sh`. To calculate for a specific release run
@@ -11,6 +11,17 @@ DEFAULT_YQ_VERSION = "4.45.1"
 # Alternatively, you can compute them manually by running
 # `shasum -b -a 384 [downloaded file] | awk '{ print $1 }' | xxd -r -p | base64`
 YQ_VERSIONS = {
+    "4.45.2": {
+        "darwin_amd64": "sha384-TBsrUTy6n6qA2hiSlpnEN6iEDDz4Tiy++AxLOpeXU1aUaI6uIuEBx8hgPYWWuD8V",
+        "darwin_arm64": "sha384-bnZ5TqsG5pcWB6gC87QKrBrjcKYmdOcSD7TpFVeCU6Nj7z5egeZzm4BH1FHbqo0e",
+        "linux_amd64": "sha384-jEOdMXHPvRiaFXWRnSA5Mw41VCKkNPv42i35i9BiVxrAnfyl/3/Li/iyQyj16QIr",
+        "linux_arm64": "sha384-4bEWn6fDQhIomb6Smzm8yw26RvqsjHh3PH/SogwWoLC9uJRoyQagY2PJZaYWxUDY",
+        "linux_s390x": "sha384-9uU3CXqjUG/SuPiHPKIUqbOVyqx7JiVOtRzeFta9IBFkJyUB0pBBOYkoDppvrmzz",
+        "linux_riscv64": "sha384-FWM1djpKjWctmhaInat/z/CcwQuiqLTeQcb0MMU5+sNiwMTuWyjvNlbwA4rRG3ZQ",
+        "linux_ppc64le": "sha384-bB03rZ0ptRt2EuFnA9SvscPMe3gVJecBvxhzPbYe7wsfoHvzzYqWffCchZVxRg+9",
+        "windows_amd64": "sha384-vG8R2+s/sD8DbeCM9H0xCy5JgtAOII7SLRx2g+ALtQZWW/q3XjXlzN2CKW/zU+EH",
+        "windows_arm64": "sha384-XHgi894S4cQ2qgJx47cPu5vtb2MOXA2YZ7QgExODwNoIPhji5wXK2MrgMB+RI7gZ",
+    },
     "4.45.1": {
         "darwin_amd64": "sha384-ZoEgzfCLmDk7eoKdJSoq/nny1iX3Cq9mMJ3gnPZ2ejhKMxSgHUQIa7MREToxYl6Z",
         "darwin_arm64": "sha384-nHYFqoarTzGba/XtpN8N3U0X9hMTg64Vn7XZ8yiF2cbJFdY3VWFVw80vsg/JXaOg",


### PR DESCRIPTION
Same as https://github.com/bazel-contrib/bazel-lib/pull/1125. I saw that `yq` has been moved to this separate repository, so I'm adding the same changes here with this PR.