### PR TITLE
fix: correct cd dir issue when executed in an external module

### DIFF
--- a/yq/private/yq.bzl
+++ b/yq/private/yq.bzl
@@ -72,10 +72,10 @@ def _yq_impl(ctx):
 
     # For split operations, yq outputs files in the same directory so we
     # must cd to the correct output dir before executing it
-    bin_dir = "/".join([ctx.bin_dir.path, ctx.label.package]) if ctx.label.package else ctx.bin_dir.path
+    bin_dir = outs[0].dirname
     escape_bin_dir = _escape_path(bin_dir)
     cmd = "cd {bin_dir} && {yq} {args} {eval_cmd} {expression} {sources} {maybe_out}".format(
-        bin_dir = ctx.bin_dir.path + "/" + ctx.label.package,
+        bin_dir = bin_dir,
         yq = escape_bin_dir + yq_bin.path,
         eval_cmd = "eval" if len(inputs) <= 1 else "eval-all",
         args = " ".join(args),


### PR DESCRIPTION
Derive the directory to cd into from the output path. When yq is called in an external module it currently assumes bin dir to be bazel-out/k8-fastbuild/bin/folder instead of bazel-out/k8-fastbuild/bin/external/external_module/folder